### PR TITLE
Set golang version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine AS builder
+FROM golang:1.19-alpine AS builder
 WORKDIR /src
 
 ENV USER=vpn-webauth


### PR DESCRIPTION
On version > 1.19  build stop on error 
`sqlite3-binding.c:33983:42: error: 'pread64' undeclared here (not in a function); did you mean 'pread'?
33983 |   { "pread64",      (sqlite3_syscall_ptr)pread64,    0  },
      |                                          ^~~~~~~`